### PR TITLE
Fix css issues

### DIFF
--- a/src/main/javadoc/slope-custom.css
+++ b/src/main/javadoc/slope-custom.css
@@ -47,17 +47,20 @@ a[name] {
     color: #353833;
 }
 
-pre {
+.block pre {
     font-family: 'DejaVu Sans Mono', monospace;
     font-size: 14px;
 
-    background-color: #323232;
+    background-color: #313131;
 
     border-style: solid;
     border-color: #000000;
     border-width: 1px;
     border-radius: .5em;
-    padding: .75em;
+    padding: .75em .5em;
+
+    overflow-wrap: normal;
+    white-space: pre-wrap;
 }
 
 h1 {


### PR DESCRIPTION
- Changed identifier for creating code blocks to require `pre`, and its
  containing element to have class `block`.
- Darkened background color a smidge
- Slightly reduced left-right padding of code blocks from .75em to .5em
- add word-wrapping and overflow-wrapping to code blocks